### PR TITLE
Fix speach file spelling, move guestbook strings to speech.json

### DIFF
--- a/config/speech.json
+++ b/config/speech.json
@@ -56,6 +56,18 @@
       "response_type": "text"
     }
   ],
+  "generic_error": {
+    "response": "An error occurred. Please try again later.",
+    "response_type":"text"
+  },
+  "guestbook_signed": {
+    "response": "Thankyou for signing the guestbook! Use -viewbook to view the other entries.",
+    "response_type": "text"
+  },
+  "guestbook_empty": {
+    "response": "The guestbook is empty! Make the first entry -signbook <message> to write your message.",
+    "response_type": "text"
+  },
   "not_recognised": {
     "response": "\uD83E\uDD2F I don't know how to respond to that, type -menu to see my commands.",
     "response_type": "text"

--- a/lib/command-handlers/functions/guestbook.js
+++ b/lib/command-handlers/functions/guestbook.js
@@ -3,7 +3,7 @@ const uuid = require('uuid');
 const AWS = require('aws-sdk');
 const dynamoDB = new AWS.DynamoDB.DocumentClient();
 
-const speech = require('../../../config/speech.json');
+const { getSpeechResponse } = require('../../utils.js');
 
 exports.sign = async (senderId, args) => {
   const message = args.join(' ');
@@ -19,7 +19,7 @@ exports.sign = async (senderId, args) => {
 
   try {
     await dynamoDB.put(params).promise();
-    return speech.guestbook_signed;
+    return getSpeechResponse('guestbook_signed')
   } catch (err) {
     throw err;
   }
@@ -39,7 +39,7 @@ exports.view = async () => {
       }, '')
     }
 
-    return speech.guestbook_empty
+    return getSpeechResponse('guestbook_empty');
 
   } catch (err) {
     throw err;

--- a/lib/command-handlers/functions/guestbook.js
+++ b/lib/command-handlers/functions/guestbook.js
@@ -3,6 +3,8 @@ const uuid = require('uuid');
 const AWS = require('aws-sdk');
 const dynamoDB = new AWS.DynamoDB.DocumentClient();
 
+const speech = require('../../../config/speech.json');
+
 exports.sign = async (senderId, args) => {
   const message = args.join(' ');
   const params = {
@@ -17,7 +19,7 @@ exports.sign = async (senderId, args) => {
 
   try {
     await dynamoDB.put(params).promise();
-    return `Thankyou for signing the guestbook! Use -viewbook to view the other entries.`;
+    return speech.guestbook_signed;
   } catch (err) {
     throw err;
   }
@@ -37,12 +39,9 @@ exports.view = async () => {
       }, '')
     }
 
-    return 'The guestbook is empty!'
+    return speech.guestbook_empty
 
   } catch (err) {
     throw err;
   }
-
-
-
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,11 @@
+const get = require('lodash/get');
+const speech = require('../config/speech.json');
+
+exports.getSpeechResponse = (key) => {
+    const commandObject = get(speech, key);
+    if (commandObject) {
+        return commandObject.response;
+    }
+
+    throw 'Invalid speech key.';
+}

--- a/rest_api/webhook/post/lib/get-command.js
+++ b/rest_api/webhook/post/lib/get-command.js
@@ -1,13 +1,13 @@
 'use strict';
 const get = require('lodash/get');
-const speach = require('./../../../../config/speach.json');
+const speech = require('./../../../../config/speech.json');
 const commandHandlers = require('./../../../../lib/command-handlers');
 
 module.exports = async (senderId, messageText) => {
   const [commandText, ...args] = messageText.split(' ');
-  const command = speach.commands.find(command => command.command_text === commandText);
+  const command = speech.commands.find(command => command.command_text === commandText);
 
-  if (!command) return speach.not_recognised;
+  if (!command) return speech.not_recognised;
 
   if (command.handler) {
     return await callHandlerFunc(senderId, command, args)

--- a/rest_api/webhook/post/lib/messaging.js
+++ b/rest_api/webhook/post/lib/messaging.js
@@ -1,7 +1,7 @@
 'use strict';
 const request = require('request-promise');
 const getCommand = require('./get-command');
-const speech = require('../../../../config/speech.json')
+const { getSpeechResponse } = require('../../../../lib/utils.js');
 
 // 0 to disable the typing indicator completely.
 // TODO: Remove the indicator, new privacy rules mean enabling it causes an error in EU and Japan.
@@ -25,7 +25,7 @@ exports.handleReceivedMessage = async event => {
     }
 
   } catch (e) {
-    await sendTextMessage(senderId, speech.generic_error);
+    await sendTextMessage(senderId, getSpeechResponse('generic_error'));
     throw(e);
   }
 };

--- a/rest_api/webhook/post/lib/messaging.js
+++ b/rest_api/webhook/post/lib/messaging.js
@@ -1,6 +1,7 @@
 'use strict';
 const request = require('request-promise');
 const getCommand = require('./get-command');
+const speech = require('../../../../config/speech.json')
 
 // 0 to disable the typing indicator completely.
 // TODO: Remove the indicator, new privacy rules mean enabling it causes an error in EU and Japan.
@@ -24,7 +25,7 @@ exports.handleReceivedMessage = async event => {
     }
 
   } catch (e) {
-    await sendTextMessage(senderId,'An error occurred.');
+    await sendTextMessage(senderId, speech.generic_error);
     throw(e);
   }
 };


### PR DESCRIPTION
- Rename `speach.json` to `speech.json`
- Update references
- Move guestbook strings into `speech.json`
- Move generic error messageg into `speech.json`
- Add `getSpeechResponse` utility