### PR TITLE
Fix NEW_VARIABLES_RESOLVER deprecation warning

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,5 @@
 service: botson-2-0
+variablesResolutionMode: 20210326
 
 provider:
   name: aws
@@ -45,7 +46,7 @@ functions:
           path: /webhook
           method: get
     environment:
-      VERIFY_TOKEN: ${ssm:/botson-facebook-verification-token~true}
+      VERIFY_TOKEN: ${ssm:/botson-facebook-verification-token}
 
   webhook_post:
     handler: rest_api/webhook/post/handler.handle
@@ -56,5 +57,5 @@ functions:
           path: /webhook
           method: post
     environment:
-      PAGE_ACCESS_TOKEN: ${ssm:/botson-facebook-page-access-token~true}
+      PAGE_ACCESS_TOKEN: ${ssm:/botson-facebook-page-access-token}
       TYPING_MS: 0


### PR DESCRIPTION
- Fixes deprecation warning from the serverless framework when deploying the bot to AWS

More info: https://www.serverless.com/framework/docs/deprecations#new-variables-resolver